### PR TITLE
Fix problems with v2.0.1 packaging (#5)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
-include LICENSE
-include README.md
+# LICENSE and README files don't need to be mentioned - 
+# setup picks them up automatically
+# include LICENSE
+# include README.md
+
+# All other files/dirs are assumed to be relative to root of project dir
+# (which is the dir containing the setup.py file)
 include jaro/strcmp95.c

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,15 @@ README = (HERE / 'README.md').read_text()
 
 setup(
     name='jaro_winkler',
-    version='2.0.1',
+    version='2.0.3',
     description='Original, standard and customisable versions of the Jaro-Winkler functions.',
     long_description=README,
-    long_description_content_type='text/markdown',
+    long_description_content_type='text/markdown',  # Needed by PyPI, which expects reStructuredText by default.
     author='Richard Milne',
     author_email='richmilne@hotmail.com',
     url='https://github.com/richmilne/JaroWinkler.git',
-    packages=['jaro'],
-    include_package_data=True,
+    packages=find_packages(),
+    include_package_data=True,   # Include files given in MANIFEST.in
     platforms=['any'],
     license='GNU General Public License v3 (GPLv3)',
     classifiers=[


### PR DESCRIPTION
Previous packages were produced with `setup.py bdist` - but either I did something different for the last release, or there's now something different about the files produced by that option, hence the linked bug report.